### PR TITLE
Use ipify as default web service

### DIFF
--- a/ddclient
+++ b/ddclient
@@ -66,6 +66,7 @@ sub T_POSTS	{'postscript'};
 
 ## strategies for obtaining an ip address.
 my %builtinweb = (
+   'ipify'        => { 'url' => 'https://api.ipify.org', },
    'dyndns'       => { 'url' => 'http://checkip.dyndns.org/', 'skip' =>
    'Current IP Address:', },
    'dnspark'      => { 'url' => 'http://ipdetect.dnspark.com/', 'skip' => 'Current Address:', },


### PR DESCRIPTION
Since many users including myself had problems with http://checkip.dyndns.org/ i suggest moving to ipify as standart service
Info: https://www.ipify.org/
Pro:
-No limit in requests
-Verry fast and responsive
-Open souce
-No Logging of visitors
-Works with IPv4 and IPv6

Con:
-?
